### PR TITLE
`xunit` and `json` reporters always use plain-text decorator (closes #86)

### DIFF
--- a/src/reporters/json.js
+++ b/src/reporters/json.js
@@ -1,8 +1,9 @@
 import BaseReporter from './base';
+import plainTextDecorator from './errors/decorators/plain-text';
 
 export default class JSONReporter extends BaseReporter {
-    constructor (task, outStream, errorDecorator) {
-        super(task, outStream, errorDecorator);
+    constructor (task, outStream) {
+        super(task, outStream, plainTextDecorator);
 
         this.currentFixture = null;
 

--- a/src/reporters/xunit.js
+++ b/src/reporters/xunit.js
@@ -2,12 +2,13 @@ import indentString from 'indent-string';
 import escapeHtml from 'escape-html';
 import wordwrap from '../utils/word-wrap';
 import BaseReporter from './base';
+import plainTextDecorator from './errors/decorators/plain-text';
 
 export default class XUnitReporter extends BaseReporter {
     static LINE_WIDTH = 100;
 
-    constructor (task, outStream, errorDecorator) {
-        super(task, outStream, errorDecorator);
+    constructor (task, outStream) {
+        super(task, outStream, plainTextDecorator);
 
         this.report             = '';
         this.startTime          = null;

--- a/test/server/reporters-test.js
+++ b/test/server/reporters-test.js
@@ -1,10 +1,12 @@
-var expect       = require('chai').expect;
-var EventEmitter = require('events').EventEmitter;
-var util         = require('util');
-var Promise      = require('promise');
-var reporters    = require('../../lib/reporters');
-var readFile     = require('../../lib/utils/read-file-relative');
-var TYPE         = require('../../lib/reporters/errors/type');
+var expect             = require('chai').expect;
+var EventEmitter       = require('events').EventEmitter;
+var util               = require('util');
+var Promise            = require('promise');
+var reporters          = require('../../lib/reporters');
+var readFile           = require('../../lib/utils/read-file-relative');
+var TYPE               = require('../../lib/reporters/errors/type');
+var ttyDecorator       = require('../../lib/reporters/errors/decorators/tty');
+var plainTextDecorator = require('../../lib/reporters/errors/decorators/plain-text');
 
 describe('Reporters', function () {
     // Runnable configuration mocks
@@ -315,7 +317,6 @@ describe('Reporters', function () {
             .catch(done);
     }
 
-
     // Tests
     it('spec', function (done) {
         testReporter('spec', done);
@@ -335,5 +336,18 @@ describe('Reporters', function () {
 
     it('xunit', function (done) {
         testReporter('xunit', done);
+    });
+
+    describe('Regression', function () {
+        it('Should force plain text decorator for reporters that target machine-readable formats(GH-86)', function () {
+            ['xunit', 'json'].forEach(function (type) {
+                var taskMock      = new TaskMock();
+                var outStreamMock = createOutStreamMock();
+                var Reporter      = reporters[type];
+                var reporter      = new Reporter(taskMock, outStreamMock, ttyDecorator);
+
+                expect(reporter.errorDecorator).eql(plainTextDecorator);
+            });
+        });
     });
 });


### PR DESCRIPTION
\cc @inikulin @AlexanderMoskovkin 