### PR TITLE
Set outStream to process.stdout if it's not specified (closed #114)

### DIFF
--- a/src/runner/index.js
+++ b/src/runner/index.js
@@ -67,7 +67,7 @@ export default class Runner {
         return this;
     }
 
-    reporter (reporter, outStream = null, errorDecorator = null) {
+    reporter (reporter, outStream, errorDecorator) {
         this.bootstrapper.reporter       = reporter;
         this.bootstrapper.errorDecorator = errorDecorator;
         this.opts.reportOutStream        = outStream;


### PR DESCRIPTION
Now we send send to the `Reporter` constructor `null` as `outStream` and `errorDecorator` parameters by default. But reporter falls back them to default values it they are `undefined`.

For fix we can write 
```js
reporter (reporter, outStream = void 0, errorDecorator = void 0) {
```
but it makes no sense because a default argument is applied if the argument is `undefined`.

/cc @inikulin 