### PR TITLE
Add eslint rules for arrow functions (closes #108) and improve report errors code

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "es6-promise": "^3.0.2",
     "es6-promisify": "^3.0.0",
     "escape-html": "^1.0.2",
+    "eslint-plugin-babel": "^2.1.1",
     "flatten": "0.0.1",
     "indent-string": "^1.2.2",
     "moment": "^2.10.3",

--- a/src/.eslintrc
+++ b/src/.eslintrc
@@ -1,0 +1,10 @@
+{
+  "rules": {
+    "babel/arrow-parens": [2, "as-needed"],
+    "arrow-spacing": [2, { "before": true, "after": true }],
+    "prefer-arrow-callback": 2
+  },
+  "plugins": [
+    "babel"
+  ]
+}

--- a/src/client/runner/action-barrier/xhr.js
+++ b/src/client/runner/action-barrier/xhr.js
@@ -1,7 +1,6 @@
 import hammerhead from '../deps/hammerhead';
 import testCafeCore from '../deps/testcafe-core';
 
-var ERROR_TYPE   = testCafeCore.ERROR_TYPE;
 var serviceUtils = testCafeCore.serviceUtils;
 
 
@@ -50,7 +49,13 @@ function onRequestsCollected () {
 
     if (barrierCtx.reqCount) {
         barrierCtx.watchdog = window.setTimeout(function () {
-            eventEmitter.emit(XHR_BARRIER_ERROR, { code: ERROR_TYPE.xhrRequestTimeout });
+            //NOTE: previously this error used in possible fail causes, which are R.I.P. now.
+            //So we just through error to the console for the debugging purposes. In IE9 console.log
+            //is defined only if dev tools are open.
+            if (window.console && window.console.log)
+                window.console.log('TestCafe encountered hanged XHR on page.');
+
+            eventEmitter.emit(XHR_BARRIER_ERROR);
             barrierCtx.callback();
         }, BARRIER_TIMEOUT);
     }
@@ -87,7 +92,7 @@ export function init () {
 
     hammerhead.on(hammerhead.EVENTS.xhrError, function (e) {
         //NOTE: previously this error used in possible fail causes, which are R.I.P. now.
-        //So we just through errot to the console for the debugging purposes. In IE9 console.log
+        //So we just through error to the console for the debugging purposes. In IE9 console.log
         //is defined only if dev tools are open.
         if (window.console && window.console.log)
             window.console.log('TestCafe encountered XHR error on page: ' + e.err);

--- a/src/compiler/index.js
+++ b/src/compiler/index.js
@@ -120,10 +120,10 @@ export default class Compiler {
     }
 
     _createOldCompilerPromise (filePath, modules) {
-        return new Promise((resolve, reject)=> {
+        return new Promise((resolve, reject) => {
             var oldCompiler = new OldCompiler(filePath, modules, this.requireReader, this.cache.sourceIndex);
 
-            oldCompiler.compile((errs, out)=> {
+            oldCompiler.compile((errs, out) => {
                 if (errs)
                     reject(errs);
                 else

--- a/src/compiler/require-reader.js
+++ b/src/compiler/require-reader.js
@@ -13,7 +13,7 @@ export default class RequireReader {
     async _analyzeRequire (require, filename, sourceIndex) {
         this.readings.push(require);
 
-        return new Promise((resolve) => {
+        return new Promise(resolve => {
             RequireAnalyzer.run(require, filename, sourceIndex, (errs, descriptor) => {
                 this.descriptorsCache[require] = descriptor;
 
@@ -29,7 +29,7 @@ export default class RequireReader {
     }
 
     async _waitForReading (require) {
-        return new Promise((resolve) => {
+        return new Promise(resolve => {
             if (!this.waiters[require])
                 this.waiters[require] = [];
 

--- a/src/reporters/base.js
+++ b/src/reporters/base.js
@@ -125,7 +125,7 @@ export default class BaseReporter {
                 reportItem.startTime = new Date();
         });
 
-        task.on('test-run-done', (testRun) => {
+        task.on('test-run-done', testRun => {
             var reportItem = this._getReportItemForTestRun(testRun);
             var userAgent  = testRun.browserConnection.userAgent;
 

--- a/src/reporters/errors/assertion-diffs/string.js
+++ b/src/reporters/errors/assertion-diffs/string.js
@@ -28,7 +28,7 @@ var markerPositionCalculators = {
 };
 
 var cutStringCalculators = {
-    [OVERFLOW_TYPES.noOverflow]: (str) => str,
+    [OVERFLOW_TYPES.noOverflow]: str => str,
 
     [OVERFLOW_TYPES.rightOverflow]: (str, diffIndex, maxStringLength, quote) => {
         var maxLength = maxStringLength - STRING_OVERFLOW_MARKER.length;

--- a/src/reporters/errors/category.js
+++ b/src/reporters/errors/category.js
@@ -3,5 +3,6 @@ export default {
     failedAssertion:    'failedAssertion',
     unhandledException: 'unhandledException',
     nativeDialogError:  'nativeDialogError',
-    timeout:            'timeout'
+    timeout:            'timeout',
+    pageLoadError:      'pageLoadError'
 };

--- a/src/reporters/errors/templates.js
+++ b/src/reporters/errors/templates.js
@@ -7,16 +7,17 @@ function escapeNewLines (str) {
     return str.replace(/(\r\n|\n|\r)/gm, '\\n');
 }
 
-function getMsgPrefix (err) {
-    return `<span data-type="user-agent">${err.userAgent}</span>\n`;
+function getMsgPrefix (err, category) {
+    return dedent`
+        <span data-type="user-agent">${err.userAgent}</span>
+        <span data-type="category">${category}</span>
+    `;
 }
 
 function getAssertionMsgPrefix (err) {
-    var assertionPrefix = err.message !== void 0 && err.message !== null ?
-                          `<span data-type="category">${CATEGORY.failedAssertion}</span>"${err.message}" assertion` :
-                          `<span data-type="category">${CATEGORY.failedAssertion}</span>Assertion`;
+    var assertionPrefix = err.message ? `"${err.message}" assertion` : 'Assertion';
 
-    return getMsgPrefix(err) + assertionPrefix;
+    return getMsgPrefix(err, CATEGORY.failedAssertion) + assertionPrefix;
 }
 
 function getDiffHeader (err) {
@@ -33,27 +34,23 @@ function getDiffHeader (err) {
 }
 
 export default {
-    [TYPE.okAssertion]: (err) => {
-        return dedent`
-            ${getAssertionMsgPrefix(err)} failed at step <span data-type="step-name">${err.stepName}</span>:
+    [TYPE.okAssertion]: err => dedent`
+        ${getAssertionMsgPrefix(err)} failed at step <span data-type="step-name">${err.stepName}</span>:
 
-                <code data-type="step-source">${escapeNewLines(err.relatedSourceCode)}</code>
+            <code data-type="step-source">${escapeNewLines(err.relatedSourceCode)}</code>
 
-            <strong>Expected: </strong>not <code>null</code>, not <code>undefined</code>, not <code>false</code>, not <code>NaN</code> and not <code>''</code>
-            <strong>Actual:   </strong><code>${escapeNewLines(err.actual)}</code>
-        `;
-    },
+        <strong>Expected: </strong>not <code>null</code>, not <code>undefined</code>, not <code>false</code>, not <code>NaN</code> and not <code>''</code>
+        <strong>Actual:   </strong><code>${escapeNewLines(err.actual)}</code>
+    `,
 
-    [TYPE.notOkAssertion]: (err) => {
-        return dedent`
-            ${getAssertionMsgPrefix(err)} failed at step <span data-type="step-name">${err.stepName}</span>:
+    [TYPE.notOkAssertion]: err => dedent`
+        ${getAssertionMsgPrefix(err)} failed at step <span data-type="step-name">${err.stepName}</span>:
 
-                <code data-type="step-source">${escapeNewLines(err.relatedSourceCode)}</code>
+            <code data-type="step-source">${escapeNewLines(err.relatedSourceCode)}</code>
 
-            <strong>Expected: </strong><code>null</code>, <code>undefined</code>, <code>false</code>, <code>NaN</code> or <code>''</code>
-            <strong>Actual:   </strong><code>${escapeNewLines(err.actual)}</code>
-        `;
-    },
+        <strong>Expected: </strong><code>null</code>, <code>undefined</code>, <code>false</code>, <code>NaN</code> or <code>''</code>
+        <strong>Actual:   </strong><code>${escapeNewLines(err.actual)}</code>
+    `,
 
     [TYPE.eqAssertion]: (err, maxStringLength) => {
         var diff          = buildDiff(err, maxStringLength);
@@ -72,228 +69,173 @@ export default {
         `;
     },
 
-    [TYPE.notEqAssertion]: (err) => {
-        return dedent`
-            ${getAssertionMsgPrefix(err)} failed at step <span data-type="step-name">${err.stepName}</span>:
+    [TYPE.notEqAssertion]: err => dedent`
+        ${getAssertionMsgPrefix(err)} failed at step <span data-type="step-name">${err.stepName}</span>:
 
-                <code data-type="step-source">${escapeNewLines(err.relatedSourceCode)}</code>
+            <code data-type="step-source">${escapeNewLines(err.relatedSourceCode)}</code>
 
-            <strong>Expected: </strong>not <code>${escapeNewLines(err.actual)}</code>
-            <strong>Actual:   </strong><code>${escapeNewLines(err.actual)}</code>
-        `;
-    },
+        <strong>Expected: </strong>not <code>${escapeNewLines(err.actual)}</code>
+        <strong>Actual:   </strong><code>${escapeNewLines(err.actual)}</code>
+    `,
 
-    [TYPE.xhrRequestTimeout]: (err) => {
-        return dedent`
-            ${getMsgPrefix(err)}<span data-type="category">${CATEGORY.timeout}</span>XMLHttpRequest timed out.
-        `;
-    },
+    [TYPE.iframeLoadingTimeout]: err => dedent`
+        ${getMsgPrefix(err, CATEGORY.timeout)}IFrame loading timed out.
+    `,
 
-    [TYPE.iframeLoadingTimeout]: (err) => {
-        return dedent`
-            ${getMsgPrefix(err)}<span data-type="category">${CATEGORY.timeout}</span>IFrame loading timed out.
-        `;
-    },
+    [TYPE.inIFrameTargetLoadingTimeout]: err => dedent`
+        ${getMsgPrefix(err, CATEGORY.timeout)}Error at step <span data-type="step-name">${err.stepName}</span>:
+        IFrame target loading timed out.
+    `,
 
-    [TYPE.inIFrameTargetLoadingTimeout]: (err) => {
-        return dedent`
-            ${getMsgPrefix(err)}<span data-type="category">${CATEGORY.timeout}</span>Error at step <span data-type="step-name">${err.stepName}</span>:
-            IFrame target loading timed out.
-        `;
-    },
-
-    [TYPE.urlUtilProtocolIsNotSupported]: (err) => {
-        return dedent`
-            ${getMsgPrefix(err)}<span data-type="category">${CATEGORY.unhandledException}</span>Failed to process the <a href="${err.destUrl}">${err.destUrl}</a> resource. TestCafe supports only HTTP and HTTPS protocols.
-        `;
-    },
-
-    [TYPE.uncaughtJSError]: (err) => {
+    [TYPE.uncaughtJSError]: err => {
         if (err.pageUrl) {
             return dedent`
-                ${getMsgPrefix(err)}<span data-type="category">${CATEGORY.unhandledException}</span>Uncaught JavaScript error <code>${err.scriptErr}</code> on page <a href="${err.pageUrl}">${err.pageUrl}</a>
+                ${getMsgPrefix(err, CATEGORY.unhandledException)}Uncaught JavaScript error <code>${err.scriptErr}</code> on page <a href="${err.pageUrl}">${err.pageUrl}</a>
             `;
         }
 
         return dedent`
-            ${getMsgPrefix(err)}<span data-type="category">${CATEGORY.unhandledException}</span>Uncaught JavaScript error <code>${err.scriptErr}</code> on page.
+            ${getMsgPrefix(err, CATEGORY.unhandledException)}Uncaught JavaScript error <code>${err.scriptErr}</code> on page.
         `;
     },
 
-    [TYPE.uncaughtJSErrorInTestCodeStep]: (err) => {
-        return dedent`
-            ${getMsgPrefix(err)}<span data-type="category">${CATEGORY.unhandledException}</span>Error at step <span data-type="step-name">${err.stepName}</span>:
-            Uncaught JavaScript error in test code - <code>${err.scriptErr}</code>.
-        `;
-    },
+    [TYPE.uncaughtJSErrorInTestCodeStep]: err => dedent`
+        ${getMsgPrefix(err, CATEGORY.unhandledException)}Error at step <span data-type="step-name">${err.stepName}</span>:
+        Uncaught JavaScript error in test code - <code>${err.scriptErr}</code>.
+    `,
 
-    [TYPE.storeDomNodeOrJqueryObject]: (err) => {
-        return dedent`
-            ${getMsgPrefix(err)}<span data-type="category">${CATEGORY.unhandledException}</span>Error at step <span data-type="step-name">${err.stepName}</span>:
-            It is not allowed to share the DOM element, jQuery object or a function between test steps via "this" object.
-        `;
-    },
+    [TYPE.storeDomNodeOrJqueryObject]: err => dedent`
+        ${getMsgPrefix(err, CATEGORY.unhandledException)}Error at step <span data-type="step-name">${err.stepName}</span>:
+        It is not allowed to share the DOM element, jQuery object or a function between test steps via "this" object.
+    `,
 
-    [TYPE.emptyFirstArgument]: (err) => {
-        return dedent`
-            ${getMsgPrefix(err)}<span data-type="category">${CATEGORY.actionError}</span>Error at step <span data-type="step-name">${err.stepName}</span>:
+    [TYPE.emptyFirstArgument]: err => dedent`
+        ${getMsgPrefix(err, CATEGORY.actionError)}Error at step <span data-type="step-name">${err.stepName}</span>:
 
-                <code data-type="step-source">${escapeNewLines(err.relatedSourceCode)}</code>
+            <code data-type="step-source">${escapeNewLines(err.relatedSourceCode)}</code>
 
-            A target element of the <code data-type="api">${err.action}</code> action has not been found in the DOM tree.
-            If this element should be created after animation or a time-consuming operation is finished, use the <code data-type="api">waitFor</code> action (available for use in code) to pause test execution until this element appears.
-        `;
-    },
+        A target element of the <code data-type="api">${err.action}</code> action has not been found in the DOM tree.
+        If this element should be created after animation or a time-consuming operation is finished, use the <code data-type="api">waitFor</code> action (available for use in code) to pause test execution until this element appears.
+    `,
 
-    [TYPE.invisibleActionElement]: (err) => {
-        return dedent`
-            ${getMsgPrefix(err)}<span data-type="category">${CATEGORY.actionError}</span>Error at step <span data-type="step-name">${err.stepName}</span>:
+    [TYPE.invisibleActionElement]: err => dedent`
+        ${getMsgPrefix(err, CATEGORY.actionError)}Error at step <span data-type="step-name">${err.stepName}</span>:
 
-                <code data-type="step-source">${escapeNewLines(err.relatedSourceCode)}</code>
+            <code data-type="step-source">${escapeNewLines(err.relatedSourceCode)}</code>
 
-            A target element <code>${err.element}</code> of the <code data-type="api">${err.action}</code> action is not visible.
-            If this element should appear when you are hovering over another element, make sure that you properly recorded the <code data-type="api">hover</code> action.
-        `;
+        A target element <code>${err.element}</code> of the <code data-type="api">${err.action}</code> action is not visible.
+        If this element should appear when you are hovering over another element, make sure that you properly recorded the <code data-type="api">hover</code> action.
+    `,
 
-    },
+    [TYPE.incorrectDraggingSecondArgument]: err => dedent`
+        ${getMsgPrefix(err, CATEGORY.actionError)}Error at step <span data-type="step-name">${err.stepName}</span>:
 
-    [TYPE.incorrectDraggingSecondArgument]: (err) => {
-        return dedent`
-            ${getMsgPrefix(err)}<span data-type="category">${CATEGORY.actionError}</span>Error at step <span data-type="step-name">${err.stepName}</span>:
+            <code data-type="step-source">${escapeNewLines(err.relatedSourceCode)}</code>
 
-                <code data-type="step-source">${escapeNewLines(err.relatedSourceCode)}</code>
+        <code data-type="api">drag</code> action drop target is incorrect.
+    `,
 
-            <code data-type="api">drag</code> action drop target is incorrect.
-        `;
-    },
+    [TYPE.incorrectPressActionArgument]: err => dedent`
+        ${getMsgPrefix(err, CATEGORY.actionError)}Error at step <span data-type="step-name">${err.stepName}</span>:
 
-    [TYPE.incorrectPressActionArgument]: (err) => {
-        return dedent`
-            ${getMsgPrefix(err)}<span data-type="category">${CATEGORY.actionError}</span>Error at step <span data-type="step-name">${err.stepName}</span>:
+            <code data-type="step-source">${escapeNewLines(err.relatedSourceCode)}</code>
 
-                <code data-type="step-source">${escapeNewLines(err.relatedSourceCode)}</code>
+        <code data-type="api">press</code> action parameter contains incorrect key code.
+    `,
 
-            <code data-type="api">press</code> action parameter contains incorrect key code.
-        `;
-    },
+    [TYPE.emptyTypeActionArgument]: err => dedent`
+        ${getMsgPrefix(err, CATEGORY.actionError)}Error at step <span data-type="step-name">${err.stepName}</span>:
 
-    [TYPE.emptyTypeActionArgument]: (err) => {
-        return dedent`
-            ${getMsgPrefix(err)}<span data-type="category">${CATEGORY.actionError}</span>Error at step <span data-type="step-name">${err.stepName}</span>:
+            <code data-type="step-source">${escapeNewLines(err.relatedSourceCode)}</code>
 
-                <code data-type="step-source">${escapeNewLines(err.relatedSourceCode)}</code>
+        The <code data-type="api">type<code> action's parameter text is empty.
+    `,
 
-            The <code data-type="api">type<code> action's parameter text is empty.
-        `;
-    },
+    [TYPE.unexpectedDialog]: err => dedent`
+        ${getMsgPrefix(err, CATEGORY.nativeDialogError)}Error at step <span data-type="step-name">${err.stepName}</span>:
+        Unexpected system <code>${err.dialog}</code> dialog <code>${err.message}</code> appeared.
+    `,
 
-    [TYPE.unexpectedDialog]: (err) => {
-        return dedent`
-            ${getMsgPrefix(err)}<span data-type="category">${CATEGORY.nativeDialogError}</span>Error at step <span data-type="step-name">${err.stepName}</span>:
-            Unexpected system <code>${err.dialog}</code> dialog <code>${err.message}</code> appeared.
-        `;
-    },
+    [TYPE.expectedDialogDoesntAppear]: err => dedent`
+        ${getMsgPrefix(err, CATEGORY.nativeDialogError)}Error at step <span data-type="step-name">${err.stepName}</span>:
+        The expected system <code>${err.dialog}</code> dialog did not appear.
+    `,
 
-    [TYPE.expectedDialogDoesntAppear]: (err) => {
-        return dedent`
-            ${getMsgPrefix(err)}<span data-type="category">${CATEGORY.nativeDialogError}</span>Error at step <span data-type="step-name">${err.stepName}</span>:
-            The expected system <code>${err.dialog}</code> dialog did not appear.
-        `;
-    },
+    [TYPE.incorrectSelectActionArguments]: err => dedent`
+        ${getMsgPrefix(err, CATEGORY.actionError)}Error at step <span data-type="step-name">${err.stepName}</span>:
 
-    [TYPE.incorrectSelectActionArguments]: (err) => {
-        return dedent`
-            ${getMsgPrefix(err)}<span data-type="category">${CATEGORY.actionError}</span>Error at step <span data-type="step-name">${err.stepName}</span>:
+            <code data-type="step-source">${escapeNewLines(err.relatedSourceCode)}</code>
 
-                <code data-type="step-source">${escapeNewLines(err.relatedSourceCode)}</code>
+        <code data-type="api">select</code> action's parameters contain an incorrect value.
+    `,
 
-            <code data-type="api">select</code> action's parameters contain an incorrect value.
-        `;
-    },
+    [TYPE.incorrectWaitActionMillisecondsArgument]: err => dedent`
+        ${getMsgPrefix(err, CATEGORY.actionError)}Error at step <span data-type="step-name">${err.stepName}</span>:
 
-    [TYPE.incorrectWaitActionMillisecondsArgument]: (err) => {
-        return dedent`
-            ${getMsgPrefix(err)}<span data-type="category">${CATEGORY.actionError}</span>Error at step <span data-type="step-name">${err.stepName}</span>:
+            <code data-type="step-source">${escapeNewLines(err.relatedSourceCode)}</code>
 
-                <code data-type="step-source">${escapeNewLines(err.relatedSourceCode)}</code>
+        <code data-type="api">wait</code> action's "milliseconds" parameter should be a positive number.
+    `,
 
-            <code data-type="api">wait</code> action's "milliseconds" parameter should be a positive number.
-        `;
-    },
+    [TYPE.incorrectWaitForActionEventArgument]: err => dedent`
+        ${getMsgPrefix(err, CATEGORY.actionError)}Error at step <span data-type="step-name">${err.stepName}</span>:
 
-    [TYPE.incorrectWaitForActionEventArgument]: (err) => {
-        return dedent`
-            ${getMsgPrefix(err)}<span data-type="category">${CATEGORY.actionError}</span>Error at step <span data-type="step-name">${err.stepName}</span>:
+            <code data-type="step-source">${escapeNewLines(err.relatedSourceCode)}</code>
 
-                <code data-type="step-source">${escapeNewLines(err.relatedSourceCode)}</code>
+        <code data-type="api">waitFor</code> action's first parameter should be a function, a CSS selector or an array of CSS selectors.
+    `,
 
-            <code data-type="api">waitFor</code> action's first parameter should be a function, a CSS selector or an array of CSS selectors.
-        `;
-    },
+    [TYPE.incorrectWaitForActionTimeoutArgument]: err => dedent`
+        ${getMsgPrefix(err, CATEGORY.actionError)}Error at step <span data-type="step-name">${err.stepName}</span>:
 
-    [TYPE.incorrectWaitForActionTimeoutArgument]: (err) => {
-        return dedent`
-            ${getMsgPrefix(err)}<span data-type="category">${CATEGORY.actionError}</span>Error at step <span data-type="step-name">${err.stepName}</span>:
+            <code data-type="step-source">${escapeNewLines(err.relatedSourceCode)}</code>
 
-                <code data-type="step-source">${escapeNewLines(err.relatedSourceCode)}</code>
+        <code data-type="api">waitFor</code> action's "timeout" parameter should be a positive number.
+    `,
 
-            <code data-type="api">waitFor</code> action's "timeout" parameter should be a positive number.
-        `;
-    },
+    [TYPE.waitForActionTimeoutExceeded]: err => dedent`
+        ${getMsgPrefix(err, CATEGORY.timeout)}Error at step <span data-type="step-name">${err.stepName}</span>:
 
-    [TYPE.waitForActionTimeoutExceeded]: (err) => {
-        return dedent`
-            ${getMsgPrefix(err)}<span data-type="category">${CATEGORY.actionError}</span>Error at step <span data-type="step-name">${err.stepName}</span>:
+            <code data-type="step-source">${escapeNewLines(err.relatedSourceCode)}</code>
 
-                <code data-type="step-source">${escapeNewLines(err.relatedSourceCode)}</code>
+        <code data-type="api">waitFor</code> action's timeout exceeded.
+    `,
 
-            <code data-type="api">waitFor</code> action's timeout exceeded.
-        `;
-    },
+    [TYPE.emptyIFrameArgument]: err => dedent`
+        ${getMsgPrefix(err, CATEGORY.actionError)}Error at step <span data-type="step-name">${err.stepName}</span>:
 
-    [TYPE.emptyIFrameArgument]: (err) => {
-        return dedent`
-            ${getMsgPrefix(err)}<span data-type="category">${CATEGORY.actionError}</span>Error at step <span data-type="step-name">${err.stepName}</span>:
+            <code data-type="step-source">${escapeNewLines(err.relatedSourceCode)}</code>
 
-                <code data-type="step-source">${escapeNewLines(err.relatedSourceCode)}</code>
+        The selector within the <code data-type="api">inIFrame</code> function returns an empty value.
+    `,
 
-            The selector within the <code data-type="api">inIFrame</code> function returns an empty value.
-        `;
-    },
+    [TYPE.iframeArgumentIsNotIFrame]: err => dedent`
+        ${getMsgPrefix(err, CATEGORY.actionError)}Error at step <span data-type="step-name">${err.stepName}</span>:
 
-    [TYPE.iframeArgumentIsNotIFrame]: (err) => {
-        return dedent`
-            ${getMsgPrefix(err)}<span data-type="category">${CATEGORY.actionError}</span>Error at step <span data-type="step-name">${err.stepName}</span>:
+            <code data-type="step-source">${escapeNewLines(err.relatedSourceCode)}</code>
 
-                <code data-type="step-source">${escapeNewLines(err.relatedSourceCode)}</code>
+        The selector within the <code data-type="api">inIFrame</code> function doesn’t return an iframe element.
+    `,
 
-            The selector within the <code data-type="api">inIFrame</code> function doesn’t return an iframe element.
-        `;
-    },
+    [TYPE.multipleIFrameArgument]: err => dedent`
+        ${getMsgPrefix(err, CATEGORY.actionError)}Error at step <span data-type="step-name">${err.stepName}</span>:
 
-    [TYPE.multipleIFrameArgument]: (err) => {
-        return dedent`
-            ${getMsgPrefix(err)}<span data-type="category">${CATEGORY.actionError}</span>Error at step <span data-type="step-name">${err.stepName}</span>:
+            <code data-type="step-source">${escapeNewLines(err.relatedSourceCode)}</code>
 
-                <code data-type="step-source">${escapeNewLines(err.relatedSourceCode)}</code>
+        The selector within the <code data-type="api">inIFrame</code> function returns more than one iframe element.
+    `,
 
-            The selector within the <code data-type="api">inIFrame</code> function returns more than one iframe element.
-        `;
-    },
+    [TYPE.incorrectIFrameArgument]: err => dedent`
+        ${getMsgPrefix(err, CATEGORY.actionError)}Error at step <span data-type="step-name">${err.stepName}</span>:
 
-    [TYPE.incorrectIFrameArgument]: (err) => {
-        return dedent`
-            ${getMsgPrefix(err)}<span data-type="category">${CATEGORY.actionError}</span>Error at step <span data-type="step-name">${err.stepName}</span>:
+            <code data-type="step-source">${escapeNewLines(err.relatedSourceCode)}</code>
 
-                <code data-type="step-source">${escapeNewLines(err.relatedSourceCode)}</code>
+        The <code data-type="api">inIFrame</code> function contains an invalid argument.
+    `,
 
-            The <code data-type="api">inIFrame</code> function contains an invalid argument.
-        `;
-    },
-
-    [TYPE.uploadCanNotFindFileToUpload]: (err) => {
+    [TYPE.uploadCanNotFindFileToUpload]: err => {
         var msg = dedent`
-            ${getMsgPrefix(err)}<span data-type="category">${CATEGORY.actionError}</span>Error at step <span data-type="step-name">${err.stepName}</span>:
+            ${getMsgPrefix(err, CATEGORY.actionError)}Error at step <span data-type="step-name">${err.stepName}</span>:
 
                 <code data-type="step-source">${escapeNewLines(err.relatedSourceCode)}</code>
 
@@ -303,23 +245,23 @@ export default {
         return msg + err.filePaths.map(path => `\n    <code>${path}</code>`).join(',');
     },
 
-    [TYPE.uploadElementIsNotFileInput]: (err) => {
-        return dedent`
-            ${getMsgPrefix(err)}<span data-type="category">${CATEGORY.actionError}</span>Error at step <span data-type="step-name">${err.stepName}</span>:
+    [TYPE.uploadElementIsNotFileInput]: err => dedent`
+        ${getMsgPrefix(err, CATEGORY.actionError)}Error at step <span data-type="step-name">${err.stepName}</span>:
 
-                <code data-type="step-source">${escapeNewLines(err.relatedSourceCode)}</code>
+            <code data-type="step-source">${escapeNewLines(err.relatedSourceCode)}</code>
 
-            <code data-type="api">upload</code> action argument does not contain a file input element.
-        `;
-    },
+        <code data-type="api">upload</code> action argument does not contain a file input element.
+    `,
 
-    [TYPE.uploadInvalidFilePathArgument]: (err) => {
-        return dedent`
-            ${getMsgPrefix(err)}<span data-type="category">${CATEGORY.actionError}</span>Error at step <span data-type="step-name">${err.stepName}</span>:
+    [TYPE.uploadInvalidFilePathArgument]: err => dedent`
+        ${getMsgPrefix(err, CATEGORY.actionError)}Error at step <span data-type="step-name">${err.stepName}</span>:
 
-                <code data-type="step-source">${escapeNewLines(err.relatedSourceCode)}</code>
+            <code data-type="step-source">${escapeNewLines(err.relatedSourceCode)}</code>
 
-            <code data-type="api">upload</code> action's "path" parameter should be a string or an array of strings.
-        `;
-    }
+        <code data-type="api">upload</code> action's "path" parameter should be a string or an array of strings.
+    `,
+
+    [TYPE.pageNotLoaded]: err => dedent`
+        ${getMsgPrefix(err, CATEGORY.pageLoadError)}${err.message}
+    `
 };

--- a/src/reporters/errors/type.js
+++ b/src/reporters/errors/type.js
@@ -9,14 +9,10 @@ export default {
     eqAssertion:    'eqAssertion',
     notEqAssertion: 'notEqAssertion',
 
-    //CLIENT_ERR.XHR_REQUEST_TIMEOUT
-    xhrRequestTimeout:                       'xhrRequestTimeout',
     //CLIENT_ERR.IFRAME_LOADING_TIMEOUT
     iframeLoadingTimeout:                    'iframeLoadingTimeout',
     //CLIENT_ERR.IN_IFRAME_TARGET_LOADING_TIMEOUT
     inIFrameTargetLoadingTimeout:            'inIFrameTargetLoadingTimeout',
-    //Hammerhead.CLIENT_ERRS.URL_UTIL_PROTOCOL_IS_NOT_SUPPORTED
-    urlUtilProtocolIsNotSupported:           'urlUtilProtocolIsNotSupported',
     //CLIENT_ERR.UNCAUGHT_JS_ERROR
     uncaughtJSError:                         'uncaughtJSError',
     //CLIENT_ERR.UNCAUGHT_JS_ERROR_IN_TEST_CODE_STEP
@@ -60,5 +56,6 @@ export default {
     //CLIENT_ERR.API_UPLOAD_ELEMENT_IS_NOT_FILE_INPUT
     uploadElementIsNotFileInput:             'uploadElementIsNotFileInput',
     //CLIENT_ERR.API_UPLOAD_INVALID_FILE_PATH_ARGUMENT
-    uploadInvalidFilePathArgument:           'uploadInvalidFilePathArgument'
+    uploadInvalidFilePathArgument:           'uploadInvalidFilePathArgument',
+    pageNotLoaded:                           'pageNotLoaded'
 };

--- a/src/runner/bootstrapper.js
+++ b/src/runner/bootstrapper.js
@@ -62,7 +62,7 @@ export default class Bootstrapper {
 
             Bootstrapper
                 ._createBrowserConnectionsReadyPromise(browserConnections)
-                .then(()=> {
+                .then(() => {
                     browserConnections.forEach(bc => bc.removeListener('error', onError));
                     clearTimeout(timeout);
                     resolve();

--- a/src/runner/test-run/index.js
+++ b/src/runner/test-run/index.js
@@ -3,6 +3,7 @@ import { readSync as read } from 'read-file-relative';
 import Mustache from 'mustache';
 import { Session } from 'testcafe-hammerhead';
 import COMMAND from './command';
+import ERROR_TYPE from '../../reporters/errors/type';
 
 
 // Const
@@ -104,8 +105,12 @@ export default class TestRun extends Session {
         this.isFileDownloading = true;
     }
 
-    handlePageError (ctx, err) {
-        this._fatalError(err);
+    handlePageError (ctx, errMsg) {
+        this._fatalError({
+            code:    ERROR_TYPE.pageNotLoaded,
+            message: errMsg
+        });
+
         ctx.redirect(this.browserConnection.idleUrl);
     }
 }

--- a/test/client/fixtures/runner/xhr-test.js
+++ b/test/client/fixtures/runner/xhr-test.js
@@ -90,19 +90,21 @@ $(document).ready(function () {
 
         expect(1);
 
-        var savedTimeout = xhrBarrier.BARRIER_TIMEOUT;
+        var savedTimeout     = xhrBarrier.BARRIER_TIMEOUT;
+        var errorEventRaised = false;
 
         xhrBarrier.setBarrierTimeout(0);
         xhrBarrier.init();
 
         var handler = function (err) {
-            strictEqual(err.code, ERROR_TYPE.xhrRequestTimeout);
+            errorEventRaised = true;
             xhrBarrier.events.off(xhrBarrier.XHR_BARRIER_ERROR, handler);
         };
 
         xhrBarrier.events.on(xhrBarrier.XHR_BARRIER_ERROR, handler);
         xhrBarrier.startBarrier(function () {
             xhrBarrier.setBarrierTimeout(savedTimeout);
+            ok(errorEventRaised);
             start();
         });
 

--- a/test/server/data/expected-test-errors/empty-first-argument
+++ b/test/server/data/expected-test-errors/empty-first-argument
@@ -1,4 +1,5 @@
 Chrome 15.0.874 / Mac OS X 10.8.1
+CATEGORY=actionError
 Error at step "Step":
 
     code

--- a/test/server/data/expected-test-errors/empty-iframe-argument
+++ b/test/server/data/expected-test-errors/empty-iframe-argument
@@ -1,4 +1,5 @@
 Chrome 15.0.874 / Mac OS X 10.8.1
+CATEGORY=actionError
 Error at step "Step":
 
     code

--- a/test/server/data/expected-test-errors/empty-type-action-argument
+++ b/test/server/data/expected-test-errors/empty-type-action-argument
@@ -1,4 +1,5 @@
 Chrome 15.0.874 / Mac OS X 10.8.1
+CATEGORY=actionError
 Error at step "Step":
 
     code

--- a/test/server/data/expected-test-errors/eq-assertion
+++ b/test/server/data/expected-test-errors/eq-assertion
@@ -1,4 +1,5 @@
 Chrome 15.0.874 / Mac OS X 10.8.1
+CATEGORY=failedAssertion
 Assertion failed at step "Step":
 
     eq(["12345678901"], ["00000000000"])

--- a/test/server/data/expected-test-errors/expected-dialog-doesnt-appear
+++ b/test/server/data/expected-test-errors/expected-dialog-doesnt-appear
@@ -1,3 +1,4 @@
 Chrome 15.0.874 / Mac OS X 10.8.1
+CATEGORY=nativeDialogError
 Error at step "Step":
 The expected system test-dialog dialog did not appear.

--- a/test/server/data/expected-test-errors/iframe-argument-is-not-iframe
+++ b/test/server/data/expected-test-errors/iframe-argument-is-not-iframe
@@ -1,4 +1,5 @@
 Chrome 15.0.874 / Mac OS X 10.8.1
+CATEGORY=actionError
 Error at step "Step":
 
     code

--- a/test/server/data/expected-test-errors/iframe-loading-timeout
+++ b/test/server/data/expected-test-errors/iframe-loading-timeout
@@ -1,2 +1,3 @@
 Chrome 15.0.874 / Mac OS X 10.8.1
+CATEGORY=timeout
 IFrame loading timed out.

--- a/test/server/data/expected-test-errors/in-iframe-target-loading-timeout
+++ b/test/server/data/expected-test-errors/in-iframe-target-loading-timeout
@@ -1,3 +1,4 @@
 Chrome 15.0.874 / Mac OS X 10.8.1
+CATEGORY=timeout
 Error at step "Step":
 IFrame target loading timed out.

--- a/test/server/data/expected-test-errors/incorrect-dragging-second-argument
+++ b/test/server/data/expected-test-errors/incorrect-dragging-second-argument
@@ -1,4 +1,5 @@
 Chrome 15.0.874 / Mac OS X 10.8.1
+CATEGORY=actionError
 Error at step "Step":
 
     code

--- a/test/server/data/expected-test-errors/incorrect-iframe-argument
+++ b/test/server/data/expected-test-errors/incorrect-iframe-argument
@@ -1,4 +1,5 @@
 Chrome 15.0.874 / Mac OS X 10.8.1
+CATEGORY=actionError
 Error at step "Step":
 
     code

--- a/test/server/data/expected-test-errors/incorrect-press-action-argument
+++ b/test/server/data/expected-test-errors/incorrect-press-action-argument
@@ -1,4 +1,5 @@
 Chrome 15.0.874 / Mac OS X 10.8.1
+CATEGORY=actionError
 Error at step "Step":
 
     code

--- a/test/server/data/expected-test-errors/incorrect-select-action-arguments
+++ b/test/server/data/expected-test-errors/incorrect-select-action-arguments
@@ -1,4 +1,5 @@
 Chrome 15.0.874 / Mac OS X 10.8.1
+CATEGORY=actionError
 Error at step "Step":
 
     code

--- a/test/server/data/expected-test-errors/incorrect-wait-action-milliseconds-arguments
+++ b/test/server/data/expected-test-errors/incorrect-wait-action-milliseconds-arguments
@@ -1,4 +1,5 @@
 Chrome 15.0.874 / Mac OS X 10.8.1
+CATEGORY=actionError
 Error at step "Step":
 
     code

--- a/test/server/data/expected-test-errors/incorrect-wait-for-action-event-argument
+++ b/test/server/data/expected-test-errors/incorrect-wait-for-action-event-argument
@@ -1,4 +1,5 @@
 Chrome 15.0.874 / Mac OS X 10.8.1
+CATEGORY=actionError
 Error at step "Step":
 
     code

--- a/test/server/data/expected-test-errors/incorrect-wait-for-action-timeout-argument
+++ b/test/server/data/expected-test-errors/incorrect-wait-for-action-timeout-argument
@@ -1,4 +1,5 @@
 Chrome 15.0.874 / Mac OS X 10.8.1
+CATEGORY=actionError
 Error at step "Step":
 
     code

--- a/test/server/data/expected-test-errors/invisible-action-element
+++ b/test/server/data/expected-test-errors/invisible-action-element
@@ -1,4 +1,5 @@
 Chrome 15.0.874 / Mac OS X 10.8.1
+CATEGORY=actionError
 Error at step "Step":
 
     code

--- a/test/server/data/expected-test-errors/multiple-iframe-argument
+++ b/test/server/data/expected-test-errors/multiple-iframe-argument
@@ -1,4 +1,5 @@
 Chrome 15.0.874 / Mac OS X 10.8.1
+CATEGORY=actionError
 Error at step "Step":
 
     code

--- a/test/server/data/expected-test-errors/not-eq-assertion
+++ b/test/server/data/expected-test-errors/not-eq-assertion
@@ -1,4 +1,5 @@
 Chrome 15.0.874 / Mac OS X 10.8.1
+CATEGORY=failedAssertion
 Assertion failed at step "Step":
 
     notEq("test", "test")

--- a/test/server/data/expected-test-errors/not-ok-assertion
+++ b/test/server/data/expected-test-errors/not-ok-assertion
@@ -1,4 +1,5 @@
 Chrome 15.0.874 / Mac OS X 10.8.1
+CATEGORY=failedAssertion
 Assertion failed at step "Step":
 
     notOk("test")

--- a/test/server/data/expected-test-errors/ok-assertion
+++ b/test/server/data/expected-test-errors/ok-assertion
@@ -1,4 +1,5 @@
 Chrome 15.0.874 / Mac OS X 10.8.1
+CATEGORY=failedAssertion
 Assertion failed at step "Step":
 
     ok(false)

--- a/test/server/data/expected-test-errors/page-not-loaded
+++ b/test/server/data/expected-test-errors/page-not-loaded
@@ -1,0 +1,3 @@
+Chrome 15.0.874 / Mac OS X 10.8.1
+CATEGORY=pageLoadError
+Failed to find a DNS-record for the resource at "example.org".

--- a/test/server/data/expected-test-errors/store-dom-node-or-jquery-object
+++ b/test/server/data/expected-test-errors/store-dom-node-or-jquery-object
@@ -1,4 +1,5 @@
 Chrome 15.0.874 / Mac OS X 10.8.1
+CATEGORY=unhandledException
 Error at step "Step":
 It is not allowed to share the DOM element, jQuery object or a function
 between test steps via "this" object.

--- a/test/server/data/expected-test-errors/uncaught-js-error
+++ b/test/server/data/expected-test-errors/uncaught-js-error
@@ -1,2 +1,3 @@
 Chrome 15.0.874 / Mac OS X 10.8.1
+CATEGORY=unhandledException
 Uncaught JavaScript error test-error on page "http://page"

--- a/test/server/data/expected-test-errors/uncaught-js-error-in-test-code-step
+++ b/test/server/data/expected-test-errors/uncaught-js-error-in-test-code-step
@@ -1,3 +1,4 @@
 Chrome 15.0.874 / Mac OS X 10.8.1
+CATEGORY=unhandledException
 Error at step "Step":
 Uncaught JavaScript error in test code - error.

--- a/test/server/data/expected-test-errors/unexpected-dialog
+++ b/test/server/data/expected-test-errors/unexpected-dialog
@@ -1,3 +1,4 @@
 Chrome 15.0.874 / Mac OS X 10.8.1
+CATEGORY=nativeDialogError
 Error at step "Step":
 Unexpected system test-dialog dialog message appeared.

--- a/test/server/data/expected-test-errors/upload-can-not-find-file-to-upload
+++ b/test/server/data/expected-test-errors/upload-can-not-find-file-to-upload
@@ -1,4 +1,5 @@
 Chrome 15.0.874 / Mac OS X 10.8.1
+CATEGORY=actionError
 Error at step "Step":
 
     code

--- a/test/server/data/expected-test-errors/upload-element-is-not-file-input
+++ b/test/server/data/expected-test-errors/upload-element-is-not-file-input
@@ -1,4 +1,5 @@
 Chrome 15.0.874 / Mac OS X 10.8.1
+CATEGORY=actionError
 Error at step "Step":
 
     code

--- a/test/server/data/expected-test-errors/upload-invalid-file-path-argument
+++ b/test/server/data/expected-test-errors/upload-invalid-file-path-argument
@@ -1,4 +1,5 @@
 Chrome 15.0.874 / Mac OS X 10.8.1
+CATEGORY=actionError
 Error at step "Step":
 
     code

--- a/test/server/data/expected-test-errors/url-util-protocol-is-not-supported
+++ b/test/server/data/expected-test-errors/url-util-protocol-is-not-supported
@@ -1,3 +1,0 @@
-Chrome 15.0.874 / Mac OS X 10.8.1
-Failed to process the "http://url" resource. TestCafe supports only HTTP and
-HTTPS protocols.

--- a/test/server/data/expected-test-errors/wait-for-action-timeout-exceeded
+++ b/test/server/data/expected-test-errors/wait-for-action-timeout-exceeded
@@ -1,4 +1,5 @@
 Chrome 15.0.874 / Mac OS X 10.8.1
+CATEGORY=timeout
 Error at step "Step":
 
     code

--- a/test/server/data/expected-test-errors/xhr-request-timeout
+++ b/test/server/data/expected-test-errors/xhr-request-timeout
@@ -1,2 +1,0 @@
-Chrome 15.0.874 / Mac OS X 10.8.1
-XMLHttpRequest timed out.

--- a/test/server/error-formatter-test.js
+++ b/test/server/error-formatter-test.js
@@ -31,6 +31,11 @@ var TaskMock = function () {
 util.inherits(TaskMock, EventEmitter);
 
 var userAgentMock = browserConnectionMock.userAgent;
+var testDecorator = Object.create(plainTextDecorator);
+
+testDecorator['span category'] = function (catgory) {
+    return 'CATEGORY=' + catgory + '\n';
+};
 
 // Output stream and errorDecorator mocks
 function createOutStreamMock () {
@@ -47,7 +52,7 @@ function assertErrorMessage (file, err) {
     var taskMock      = new TaskMock();
     var outStreamMock = createOutStreamMock();
     var Reporter      = reporters['list'];
-    var reporter      = new Reporter(taskMock, outStreamMock, plainTextDecorator);
+    var reporter      = new Reporter(taskMock, outStreamMock, testDecorator);
 
     reporter._write(reporter._formatError(err));
 
@@ -122,15 +127,6 @@ describe('Error formatter', function () {
     });
 
     describe('Errors', function () {
-        it('Should format "xhrRequestTimeout" error message', function () {
-            var err = {
-                code:      TYPE.xhrRequestTimeout,
-                userAgent: userAgentMock
-            };
-
-            assertErrorMessage('xhr-request-timeout', err);
-        });
-
         it('Should format "iframeLoadingTimeout" error message', function () {
             var err = {
                 code:      TYPE.iframeLoadingTimeout,
@@ -148,16 +144,6 @@ describe('Error formatter', function () {
             };
 
             assertErrorMessage('in-iframe-target-loading-timeout', err);
-        });
-
-        it('Should format "urlUtilProtocolIsNotSupported" error message', function () {
-            var err = {
-                code:      TYPE.urlUtilProtocolIsNotSupported,
-                destUrl:   'http://url',
-                userAgent: userAgentMock
-            };
-
-            assertErrorMessage('url-util-protocol-is-not-supported', err);
         });
 
         it('Should format "uncaughtJSError" error message', function () {
@@ -405,6 +391,16 @@ describe('Error formatter', function () {
             };
 
             assertErrorMessage('upload-invalid-file-path-argument', err);
+        });
+
+        it('Should format "pageNotLoaded" error message', function () {
+            var err = {
+                code:      TYPE.pageNotLoaded,
+                message:   'Failed to find a DNS-record for the resource at <a href="example.org">example.org</a>.',
+                userAgent: userAgentMock
+            };
+
+            assertErrorMessage('page-not-loaded', err);
         });
     });
 


### PR DESCRIPTION
Report errors improvements:
- Wrap hammerhead error messages with pageNotLoaded error (fixes #120)
- Add error category testing
- Remove unused errors

\cc @kirovboris @AlexanderMoskovkin 