### PR TITLE
Runner.browser() now accepts browser path (fixes #128)

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "parse5": "^1.5.0",
     "qrcode-terminal": "^0.10.0",
     "read-file-relative": "^1.2.0",
-    "testcafe-browser-natives": "^0.9.1",
+    "testcafe-browser-natives": "^0.10.0",
     "testcafe-hammerhead": "^0.2.1",
     "uglify-js": "1.2.6",
     "useragent": "^2.1.7"

--- a/src/messages.js
+++ b/src/messages.js
@@ -2,7 +2,7 @@ export const MESSAGE = {
     browserDisconnected:                'The {userAgent} browser disconnected. This problem may appear when a browser hangs or is closed, or due to network issues.',
     cantRunAgainstDisconnectedBrowsers: 'The following browsers disconnected: {userAgents}. Tests will not be run.',
     cantEstablishBrowserConnection:     'Unable to establish one or more of the specified browser connections. This can be caused by network issues or remote device failure.',
-    cantFindBrowserForAlias:            'Cannot find a corresponding browser for the following alias: {alias}.',
+    cantFindBrowser:                    'Unable to find the browser. "{browser}" is not a browser alias or path to an executable file.',
     browserNotSet:                      'No browser selected to test against.',
     testSourcesNotSet:                  'No test file specified.',
     noTestsToRun:                       'No tests to run. Either the test files contain no tests or the filter function is too restrictive.',

--- a/src/runner/bootstrapper.js
+++ b/src/runner/bootstrapper.js
@@ -1,5 +1,5 @@
 import { Promise } from 'es6-promise';
-import { getInstallations as getBrowserInstallations } from 'testcafe-browser-natives';
+import { getBrowserInfo } from 'testcafe-browser-natives';
 import reporters from '../reporters';
 import BrowserConnection from '../browser-connection';
 import LocalBrowserConnection from '../browser-connection/local';
@@ -27,17 +27,17 @@ export default class Bootstrapper {
         return Promise.all(ready);
     }
 
-    static async _convertBrowserAliasToBrowserInfo (alias) {
-        if (typeof alias !== 'string')
-            return alias;
+    static async _convertAliasOrPathToBrowserInfo (browser) {
+        if (typeof browser === 'string') {
+            var browserInfo = await getBrowserInfo(browser);
 
-        var installations = await getBrowserInstallations();
-        var browserInfo   = installations[alias.toLowerCase()];
+            if (!browserInfo)
+                throw new Error(getText(MESSAGE.cantFindBrowser, browser));
 
-        if (!browserInfo)
-            throw new Error(getText(MESSAGE.cantFindBrowserForAlias, alias));
+            return browserInfo;
+        }
 
-        return browserInfo;
+        return browser;
     }
 
     _createConnectionFromBrowserInfo (browserInfo) {
@@ -86,7 +86,7 @@ export default class Bootstrapper {
 
         this._checkForDisconnectedBrowsers();
 
-        var browsers           = await Promise.all(this.browsers.map(Bootstrapper._convertBrowserAliasToBrowserInfo));
+        var browsers           = await Promise.all(this.browsers.map(Bootstrapper._convertAliasOrPathToBrowserInfo));
         var browserConnections = browsers.map(browser => this._createConnectionFromBrowserInfo(browser));
 
         try {


### PR DESCRIPTION
\cc @AlexanderMoskovkin @AndreyBelym 